### PR TITLE
Guard if child.stdout or child.stderr are null

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,13 +13,17 @@ module.exports = function(/* command, args, options, callback */) {
 		callback( error );
 	});
 
-	child.stdout.on( "data", function( data ) {
-		stdout += data;
-	});
+	if (child.stdout) {
+			child.stdout.on( "data", function( data ) {
+			stdout += data;
+		});
+	}
 
-	child.stderr.on( "data", function( data ) {
-		stderr += data;
-	});
+	if (child.stderr) {
+		child.stderr.on( "data", function( data ) {
+			stderr += data;
+		});
+	}
 
 	child.on( "close", function( code ) {
 		if ( hadError ) {


### PR DESCRIPTION
`child.stdout` or `child.stderr` could be null if 'inherit' is passed to child_process's [`options.stdio`](https://nodejs.org/api/child_process.html#child_process_options_stdio)